### PR TITLE
Upgrade Feast transformer for v0.12.1

### DIFF
--- a/docs/samples/v1beta1/transformer/feast/README.md
+++ b/docs/samples/v1beta1/transformer/feast/README.md
@@ -3,7 +3,7 @@ Transformer is an `InferenceService` component which does pre/post processing al
 
 ## Setup
 
-1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
+1. Your ~/.kube/config should point to a cluster with [KServe installed](https://github.com/kserve/kserve/#installation).
 2. Your cluster's Istio Ingress gateway must be [network accessible](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).
 3. Your Feast online store is populated with driver [data](https://github.com/tedhtchang/populate_feast_online_store/blob/main/driver_stats.parquet), instructions available [here](https://github.com/tedhtchang/populate_feast_online_store), and network accessible.
 
@@ -70,13 +70,13 @@ Expected Output
 >
 * upload completely sent off: 57 out of 57 bytes
 < HTTP/1.1 200 OK
-< content-length: 117
+< content-length: 119
 < content-type: application/json; charset=UTF-8
-< date: Thu, 27 May 2021 00:34:21 GMT
+< date: Thu, 02 Sep 2021 19:27:55 GMT
 < server: istio-envoy
-< x-envoy-upstream-service-time: 47
+< x-envoy-upstream-service-time: 30
 <
 * Connection #0 to host 1.2.3.4 left intact
-{"predictions": [1.8440737040128852, 1.7381656744054226, 3.6771303027855993, 2.241143189554492, 0.06753551272342406]}
+{"predictions": [-1.7783805127914718, 2.7682636004737162, 3.8109928578957977, 0.31319656700671317, 0.7741179292417257]}
 ```
 

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer.Dockerfile
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 RUN apt-get update \
 && apt-get install -y --no-install-recommends git

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer.yaml
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer.yaml
@@ -17,9 +17,9 @@ spec:
       - --entity_ids
       - driver_id
       - --feature_refs
-      - driver_statistics:acc_rate 
-      - driver_statistics:avg_daily_trips 
-      - driver_statistics:conv_rate
+      - driver_hourly_stats:acc_rate
+      - driver_hourly_stats:avg_daily_trips
+      - driver_hourly_stats:conv_rate
   predictor:
     sklearn:
       storageUri: "gs://pv-kfserving/driver"

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
@@ -32,7 +32,7 @@ parser.add_argument(
 parser.add_argument(
     "--feast_serving_url",
     type=str,
-    help="The url of the Feast Serving Service.", required=True)
+    help="The url of the Feast feature server.", required=True)
 parser.add_argument(
     "--entity_ids",
     type=str, nargs="+",

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer/driver_transformer.py
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer/driver_transformer.py
@@ -15,8 +15,8 @@
 from typing import List, Dict
 import logging
 import kserve
-
-from feast import Client
+import http.client
+import json
 
 logging.basicConfig(level=kserve.constants.KSERVE_LOGLEVEL)
 
@@ -26,7 +26,7 @@ class DriverTransformer(kserve.KFModel):
     Task and returns a KFServing compatible response.
 
     Args:
-        kfserving (class object): The KFModel class from the KFServing
+        kserve (class object): The KFModel class from the KFServing
         modeule is passed here.
     """
     def __init__(self, name: str,
@@ -40,7 +40,7 @@ class DriverTransformer(kserve.KFModel):
         Args:
             name (str): Name of the model.
             predictor_host (str): The host in which the predictor runs.
-            feast_serving_url (str): The Feast serving URL, in the form
+            feast_serving_url (str): The Feast feature server URL, in the form
             of <host_name:port>
             entity_ids (List[str]): The entity IDs for which to retrieve
             features from the Feast feature store
@@ -49,9 +49,10 @@ class DriverTransformer(kserve.KFModel):
         """
         super().__init__(name)
         self.predictor_host = predictor_host
-        self.client = Client(serving_url=feast_serving_url)
+        self.feast_serving_url = feast_serving_url
         self.entity_ids = entity_ids
         self.feature_refs = feature_refs
+        self.feature_refs_key = [feature_refs[i].replace(":", "__") for i in range(len(feature_refs))]
 
         logging.info("Model name = %s", name)
         logging.info("Predictor host = %s", predictor_host)
@@ -61,18 +62,21 @@ class DriverTransformer(kserve.KFModel):
 
         self.timeout = 100
 
-    def buildEntityRow(self, instance) -> Dict:
+    def buildEntityRow(self, inputs) -> Dict:
         """Build an entity row and return it as a dict.
 
         Args:
-            instance (list): entity id attributes to identify a unique entity
+            inputs (Dict): entity ids to identify unique entities
 
         Returns:
             Dict: Returns the entity id attributes as an entity row
 
         """
-        entity_row = {self.entity_ids[i]: instance[i] for i in range(len(instance))}
-        return entity_row
+        entity_rows = {}
+        for i in range(len(self.entity_ids)):
+            entity_rows[self.entity_ids[i]] = [instance[i] for instance in inputs['instances']]
+
+        return entity_rows
 
     def buildPredictRequest(self, inputs, features) -> Dict:
         """Build the predict request for all entitys and return it as a dict.
@@ -86,11 +90,12 @@ class DriverTransformer(kserve.KFModel):
 
         """
         request_data = []
-        for i in range(len(inputs['instances'])):
-            entity_req = [features[self.feature_refs[j]][i] for j in range(len(self.feature_refs))]
+        for i in range(len(features["field_values"])):
+            entity_req = [features["field_values"][i]["fields"][self.feature_refs_key[j]]
+                          for j in range(len(self.feature_refs_key))]
             for j in range(len(self.entity_ids)):
-                entity_req.append(inputs['instances'][i][j])
-            request_data.insert(i, entity_req)
+                entity_req.append(features["field_values"][i]["fields"][self.entity_ids[j]])
+                request_data.insert(i, entity_req)
 
         return {'instances': request_data}
 
@@ -104,8 +109,16 @@ class DriverTransformer(kserve.KFModel):
             Dict: Returns the request input after ingesting online features
         """
 
-        entity_rows = [self.buildEntityRow(instance) for instance in inputs['instances']]
-        features = self.client.get_online_features(feature_refs=self.feature_refs, entity_rows=entity_rows).to_dict()
+        headers = {"Content-type": "application/json", "Accept": "application/json"}
+        params = {'features': self.feature_refs, 'entities': self.buildEntityRow(inputs),
+                  'full_feature_names': True}
+        json_params = json.dumps(params)
+
+        conn = http.client.HTTPConnection(self.feast_serving_url)
+        conn.request("GET", "/get-online-features/", json_params, headers)
+        resp = conn.getresponse()
+        logging.info("The online feature rest request status is %s", resp.status)
+        features = json.loads(resp.read().decode())
 
         outputs = self.buildPredictRequest(inputs, features)
 

--- a/docs/samples/v1beta1/transformer/feast/setup.py
+++ b/docs/samples/v1beta1/transformer/feast/setup.py
@@ -22,7 +22,7 @@ tests_require = [
 
 setup(
     name='driver_transformer',
-    version='0.1.0',
+    version='0.2.0',
     author_email='chhuang@us.ibm.com',
     license='../../LICENSE.txt',
     url='https://github.com/kserve/kserve/docs/samples/v1beta1/transformer/feast/driver_transformer',
@@ -31,10 +31,9 @@ setup(
     python_requires='>=3.6',
     packages=find_packages("driver_transformer"),
     install_requires=[
-        "kfserving>=0.5.1",
+        "kserve",
         "requests>=2.22.0",
-        "numpy>=1.16.3",
-        "feast==0.9.0"
+        "numpy>=1.16.3"
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require}


### PR DESCRIPTION
Made the following changes for Feast transformer to support the
latest Feast v0.12.1
1. Change the python client API to rest API
2. Use the new Feast feature server
3. Use python 3.8
4. Update sample outputs in doc

It is to replicate [this PR](https://github.com/kubeflow/kfserving/pull/1790) in KFServing

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md

2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews

3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md

4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Update Feast transformer to work with the latest Feast version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
